### PR TITLE
Updating csproj to support .NET Core and .NET Framework

### DIFF
--- a/MarkdownLog/MarkdownLog.csproj
+++ b/MarkdownLog/MarkdownLog.csproj
@@ -1,102 +1,29 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+  <PropertyGroup Label="Configuration">
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+  </PropertyGroup>
   <PropertyGroup>
-    <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{58003E79-47E0-47D6-BF62-82051EFC1E8B}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>MarkdownLog</RootNamespace>
-    <AssemblyName>MarkdownLog</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile24</TargetFrameworkProfile>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <TargetFramework>netstandard1.5</TargetFramework>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyResourceLanguageAttribute>false</GenerateAssemblyResourceLanguageAttribute>
+    <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="GanttChartActivity.cs" />
-    <Compile Include="GanttChart.cs" />
-    <Compile Include="BarChart.cs" />
-    <Compile Include="BarChartDataPoint.cs" />
-    <Compile Include="BlockQuote.cs" />
-    <Compile Include="BulletedList.cs" />
-    <Compile Include="CodeBlock.cs" />
-    <Compile Include="ITableCell.cs" />
-    <Compile Include="EmptyTableCell.cs" />
-    <Compile Include="MarkdownDeep\Abbreviation.cs" />
-    <Compile Include="MarkdownDeep\Block.cs" />
-    <Compile Include="MarkdownDeep\BlockProcessor.cs" />
-    <Compile Include="MarkdownDeep\FootnoteReference.cs" />
-    <Compile Include="MarkdownDeep\HtmlTag.cs" />
-    <Compile Include="MarkdownDeep\LinkDefinition.cs" />
-    <Compile Include="MarkdownDeep\LinkInfo.cs" />
-    <Compile Include="MarkdownDeep\MardownDeep.cs" />
-    <Compile Include="MarkdownDeep\SpanFormatter.cs" />
-    <Compile Include="MarkdownDeep\StringScanner.cs" />
-    <Compile Include="MarkdownDeep\TableSpec.cs" />
-    <Compile Include="MarkdownDeep\Token.cs" />
-    <Compile Include="MarkdownDeep\Utils.cs" />
-    <Compile Include="MarkdownElement.cs" />
-    <Compile Include="MarkdownToHtmlConverter.cs" />
-    <Compile Include="MarkdownToHtmlExtensions.cs" />
-    <Compile Include="NumberExtensions.cs" />
-    <Compile Include="TableColumn.cs" />
-    <Compile Include="TableColumnAlignment.cs" />
-    <Compile Include="TableCell.cs" />
-    <Compile Include="TableCellRenderSpecification.cs" />
-    <Compile Include="TableOptions.cs" />
-    <Compile Include="TableRow.cs" />
-    <Compile Include="Header.cs" />
-    <Compile Include="HeaderBase.cs" />
-    <Compile Include="HorizontalRule.cs" />
-    <Compile Include="IIosTableViewCell.cs" />
-    <Compile Include="IIosTableViewHeaderCell.cs" />
-    <Compile Include="TableView.cs" />
-    <Compile Include="IosTableViewCell.cs" />
-    <Compile Include="TableViewCellAccessory.cs" />
-    <Compile Include="IosTableViewCheckmarkCell.cs" />
-    <Compile Include="IosTableViewHeaderCell.cs" />
-    <Compile Include="TableViewSection.cs" />
-    <Compile Include="ListBase.cs" />
-    <Compile Include="ListItem.cs" />
-    <Compile Include="MarkdownContainer.cs" />
-    <Compile Include="NumberedList.cs" />
-    <Compile Include="Paragraph.cs" />
-    <Compile Include="RawMarkdown.cs" />
-    <Compile Include="SubHeader.cs" />
-    <Compile Include="IMarkdownElement.cs" />
-    <Compile Include="MarkDownBuilderExtensions.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="StringExtensions.cs" />
-    <Compile Include="Table.cs" />
-    <Compile Include="ReflectionExtensions.cs" />
+    <Compile Include="**\*.cs" />
   </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Sdk" Version="1.0.0-alpha-20161104-2">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="NETStandard.Library" Version="1.6.1" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/MarkdownLog/ReflectionExtensions.cs
+++ b/MarkdownLog/ReflectionExtensions.cs
@@ -51,7 +51,7 @@ namespace MarkdownLog
                 case TypeCode.Single:
                     return true;
                 case TypeCode.Object:
-                    if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+                    if (type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
                     {
                         return Nullable.GetUnderlyingType(type).IsFloatingPointNumber();
                     }
@@ -79,7 +79,7 @@ namespace MarkdownLog
                 case TypeCode.UInt64:
                     return true;
                 case TypeCode.Object:
-                    if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+                    if (type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
                     {
                         return Nullable.GetUnderlyingType(type).IsWholeNumber();
                     }

--- a/UnitTests/TableTests.cs
+++ b/UnitTests/TableTests.cs
@@ -204,7 +204,7 @@ namespace UnitTests.MarkdownLog
                 new{Name = "Bette Davis", Nominations = 10, Awards=2},
                 new{Name = "Laurence Olivier", Nominations = 10, Awards=1},
                 new{Name = "Spencer Tracy", Nominations = 9, Awards=2}
-                
+
             };
 
             data.ToMarkdownTable().AssertOutputEquals(
@@ -221,7 +221,7 @@ namespace UnitTests.MarkdownLog
         [TestMethod]
         public void TestColumnsCanBeSpecifiedForAutomaticallyBuiltTables()
         {
-            var path = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            var path = Path.GetTempPath();
 
             new DirectoryInfo(path).GetFiles()
                 .ToMarkdownTable(i => i.Name, i => i.Length, i => (int)(DateTime.Now - i.CreationTime).TotalDays)
@@ -257,7 +257,7 @@ namespace UnitTests.MarkdownLog
         public void TestDecimalValuesAreFormattedToTwoDecimalPlaces()
         {
             var squareRoots = Enumerable.Range(0, 12).Select(x => new {X = x*10, Sqrt = Math.Sqrt(x*10)});
-            
+
             squareRoots.ToMarkdownTable().WriteToTrace();
         }
 
@@ -349,7 +349,7 @@ namespace UnitTests.MarkdownLog
             md.Append(simpsons.ToMarkdownTable(TableOptions.ExcludeCollectionProperties));
 
             Console.WriteLine(md);
-            
+
         }
 
     }

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,103 +1,32 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{115E4845-076E-4615-9FA1-2FFEBE4D6042}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>UnitTests.MarkdownLog</RootNamespace>
+    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
     <AssemblyName>UnitTests.MarkdownLog</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
-    <IsCodedUITest>False</IsCodedUITest>
-    <TestProjectType>UnitTest</TestProjectType>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-  </ItemGroup>
-  <Choose>
-    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
-  <ItemGroup>
-    <Compile Include="GanttChartTests.cs" />
-    <Compile Include="BarChartTests.cs" />
-    <Compile Include="BlockquoteTests.cs" />
-    <Compile Include="DocumentationExamples.cs" />
-    <Compile Include="NumberExtensionsTests.cs" />
-    <Compile Include="TableTests.cs" />
-    <Compile Include="CodeBlockTests.cs" />
-    <Compile Include="ListTests.cs" />
-    <Compile Include="HeaderTests.cs" />
-    <Compile Include="HorizontalRuleTests.cs" />
-    <Compile Include="ParagraphTests.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="IosTableViewTests.cs" />
-    <Compile Include="StringExtensionsTests.cs" />
-    <Compile Include="TestExtensions.cs" />
-    <Compile Include="ReflectionExtensionsTests.cs" />
+    <Compile Include="**\*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\MarkdownLog\MarkdownLog.csproj">
-      <Project>{58003E79-47E0-47D6-BF62-82051EFC1E8B}</Project>
-      <Name>MarkdownLog</Name>
-    </ProjectReference>
+    <PackageReference Include="Microsoft.NET.Sdk" Version="1.0.0-alpha-20161104-2">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20161123-03" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.1.5-preview" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.0.6-preview" />
   </ItemGroup>
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <ItemGroup>
+    <ProjectReference Include="..\MarkdownLog\MarkdownLog.csproj" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>


### PR DESCRIPTION
1. Updated MarkdownLog.csproj to the new .NET Core csproj (.netstandard1.5 library)
    - Changed type.IsGenericType to type.GetTypeInfo().IsGenericType
2. Updated the UnitTests project to be a .NET Core App project/test (netcoreapp1.0)
    - Updated test to get TEMP path instead of MyDocuments as "Environment.SpecialFolder.MyDocuments" is not part of .NET Core 1.0 and it's not necessary for this test.

### How to build the library?

In order to build the library you will need, at least, .NET Core SDK 1.0 Preview 3 build 004056 installed. It can be downloaded from here: https://github.com/dotnet/core/blob/master/release-notes/preview3-download.md, as an installer or binaries.

It can also be scripted like the code below:

```bat
@echo off
@if defined _echo echo on

setlocal
  set errorlevel=

  echo Installing .NET Core SDK 1.0 Preview 3 build 004056.

  set DotNet_Path=%~dp0tools\bin
  set Init_Tools_Log=%DotNet_Path%\install.log

  if not exist "%DotNet_Path%" mkdir "%DotNet_Path%"
  if not exist "%DotNet_Path%" (
    echo ERROR: Failed to create .NET Core SDK output directory.
    exit /b 1
  )

  set DotNet_Version=1.0.0-preview3-004056
  set DotNet_Installer_Url=https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1

  echo Downloading dotnet installer script to "%DotNet_Path%\dotnet-install.ps1"
  powershell -NoProfile -ExecutionPolicy unrestricted -Command "Invoke-WebRequest -Uri '%DotNet_Installer_Url%' -OutFile '%DotNet_Path%\dotnet-install.ps1'"

  echo Executing dotnet installer script "%DotNet_Path%\dotnet-install.ps1"
  powershell -NoProfile -ExecutionPolicy unrestricted -Command "%DotNet_Path%\dotnet-install.ps1 -InstallDir %DotNet_Path% -Version '%DotNet_Version%'"

  if not exist "%DotNet_Path%\dotnet.exe" (
    echo ERROR: Could not install dotnet cli correctly. See '%Init_Tools_Log%' for more details.
    exit /b 1
  )

  set "path=%DotNet_Path%;%path%"
  dotnet.exe --version
endlocal& (
set "path=%path%"
exit /b %errorlevel%
)
```

Then, to build the MarkdownLog library you can run the following commands on the MarkdownLog folder:

  dotnet restore
  dotnet build -c [debug|release]

Finally, to build and run the unit tests, go to the UnitTests folder and run the following commands:

  dotnet restore
  dotnet build -c [debug|release] --no-dependencies
  dotnet test -c [debug|release]

Note that without the option --no-dependencies, the build step will build the MarkdownLog library.